### PR TITLE
Enhancements for multi zone devices in musiccast groups

### DIFF
--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -16,6 +16,7 @@ MC_LINK_SOURCES = [MC_LINK, MAIN_SYNC]
 
 NULL_GROUP = "00000000000000000000000000000000"
 
+
 class MusicCastData:
     """Object that holds data for a MusicCast device."""
 
@@ -135,6 +136,7 @@ class MusicCastDevice:
         self.device = AsyncDevice(client, ip, self.event_loop, self.handle)
         self._callbacks = set()
         self._group_update_callbacks = set()
+        self.group_reduce_by_source = False
         self.data = MusicCastData()
 
         # the following data must not be updated frequently
@@ -235,8 +237,13 @@ class MusicCastDevice:
 
         self.data.zones[zone_id].input = new_input
         if trigger_group_cb:
-            for cb in self._group_update_callbacks:
-                await cb()
+            if self.data.zones[zone_id].input != MC_LINK:
+                self.group_reduce_by_source = True
+            try:
+                for cb in self._group_update_callbacks:
+                    await cb()
+            finally:
+                self.group_reduce_by_source = False
 
     # -----Data Fetching-----
 

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -870,7 +870,7 @@ class MusicCastDevice:
         async with self.data.group_update_lock:
             await self.select_source(zone_id, MC_LINK)
 
-            if await self.check_group_data([lambda: self._check_source(zone_id, MC_LINK)]):
+            if await self.check_group_data([lambda: self._check_source(MC_LINK, zone_id)]):
                 return
 
         if retry:


### PR DESCRIPTION
- If a source is changed from MC_LINK to something else, the group update callbacks will be triggered
  - If this update was a group reduce (source was MC_LINK before and is something else now), a flag named group_reduce_by_source is set
- Add a method to let a zone join a group, another zone of the same device is already part of
