### PR TITLE
Add parts of the DLNA protocol to support URL Playback

### DIFF
--- a/aiomusiccast/const.py
+++ b/aiomusiccast/const.py
@@ -68,3 +68,12 @@ ZONE_FUNC_LIST_TO_FEATURE_MAPPING = {
     "audio_select": ZoneFeature.AUDIO_SELECT,
     "surr_decoder_type": ZoneFeature.SURR_DECODER_TYPE,
 }
+
+MIME_TYPE_UPNP_CLASS = {
+    "application/x-mpegurl": "object.item.videoItem",
+    "image": "object.item.imageItem",
+    "video": "object.item.videoItem",
+    "application/dash+xml": "object.item.videoItem",
+    "application/vnd.apple.mpegurl": "object.item.videoItem",
+    "audio": "object.item.audioItem",
+}

--- a/aiomusiccast/exceptions.py
+++ b/aiomusiccast/exceptions.py
@@ -1,8 +1,14 @@
 class MusicCastException(Exception):
     pass
 
+
 class MusicCastGroupException(MusicCastException):
     pass
 
+
 class MusicCastConnectionException(MusicCastException):
+    pass
+
+
+class MusicCastConfigurationException(MusicCastGroupException):
     pass

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -5,10 +5,9 @@ import logging
 import math
 from datetime import datetime
 from typing import Dict, List
-from urllib.parse import urlparse, urlunparse, quote_plus
 
-from async_upnp_client import UpnpDevice, UpnpFactory, UpnpService, UpnpStateVariable, UpnpError
-from async_upnp_client.aiohttp import AiohttpRequester, AiohttpSessionRequester
+from async_upnp_client import UpnpFactory
+from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.profiles.dlna import DmrDevice, DeviceState
 
 from .pyamaha import AsyncDevice, Clock, Dist, NetUSB, System, Tuner, Zone

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -1,5 +1,5 @@
 from aiomusiccast.const import DEVICE_FUNC_LIST_TO_FEATURE_MAPPING, DeviceFeature, ZONE_FUNC_LIST_TO_FEATURE_MAPPING, ZoneFeature
-from aiomusiccast.exceptions import MusicCastGroupException
+from aiomusiccast.exceptions import MusicCastGroupException, MusicCastConfigurationException
 import asyncio
 import logging
 import math
@@ -175,6 +175,8 @@ class MusicCastDevice:
     async def dlna_dmr(self):
         # dlna client
         if not self._dlna_dmr:
+            if not self.upnp_description:
+                raise MusicCastConfigurationException("There is no upnp_description URL set for client %s.", self.ip)
             requester = AiohttpSessionRequester(self.client, True)
             upnp_factory = UpnpFactory(
                 requester, disable_state_variable_validation=True

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -669,24 +669,18 @@ class MusicCastDevice:
         # Stop current playing media
         if (await self.dlna_dmr()).can_stop:
             await (await self.dlna_dmr()).async_stop()
-            print("send stop")
-        await asyncio.sleep(2)
+
         # Queue media
         await (await self.dlna_dmr()).async_set_transport_uri(
             media_id, title
         )
-        print("queued media")
-        print("waiting for ready to play")
+
         await (await self.dlna_dmr()).async_wait_for_can_play()
-        print("ready to play")
         # If already playing, no need to call Play
         if (await self.dlna_dmr()).state == DeviceState.PLAYING:
-            print("already playing")
             return
 
-        await asyncio.sleep(2)
         await (await self.dlna_dmr()).async_play()
-        print("sent play")
 
     # -----Properties-----
 

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -666,19 +666,10 @@ class MusicCastDevice:
         )
 
     async def play_url_media(self, media_id, title):
-        # Stop current playing media
-        if (await self.dlna_dmr()).can_stop:
-            await (await self.dlna_dmr()).async_stop()
-
         # Queue media
         await (await self.dlna_dmr()).async_set_transport_uri(
             media_id, title
         )
-
-        await (await self.dlna_dmr()).async_wait_for_can_play()
-        # If already playing, no need to call Play
-        if (await self.dlna_dmr()).state == DeviceState.PLAYING:
-            return
 
         await (await self.dlna_dmr()).async_play()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 
 python = "^3.8"
 aiohttp = "^3.7.4"
+async-upnp-client = "^0.16"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 
 python = "^3.8"
 aiohttp = "^3.7.4"
-async-upnp-client = "^0.16"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Adds a new function play_url_media, which a local http URL can be passed to. To support this, the DLNA protocol is used. For that reason it was necessary to add the upnp_description URL to the init function of MusicCastDevice. This parameter is not mandatory and all other functions are expected to be still working, if it is not provided.