### PR TITLE
Hotfix UDP decoding exception handling

### DIFF
--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -173,6 +173,9 @@ class MusicCastDevice:
 
     async def handle(self, message):
         """Handle udp events."""
+        if message is None:
+            await self.fetch()
+
         for parameter in message:
             if parameter in ["main", "zone2", "zone3", "zone4"]:
                 new_zone_data = message[parameter]

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -91,7 +91,11 @@ class MusicCastUdpProtocol(asyncio.DatagramProtocol):
         self.transport = transport
 
     def datagram_received(self, data, addr):
-        message = data.decode()
+        try:
+            message = data.decode()
+        except UnicodeDecodeError:
+            _LOGGER.error("Received non UTF-8 compliant message")
+            return
         try:
             data = json.loads(message)
             asyncio.create_task(self.handle_event(data))

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -91,16 +91,20 @@ class MusicCastUdpProtocol(asyncio.DatagramProtocol):
         self.transport = transport
 
     def datagram_received(self, data, addr):
+        message_data = None
+        message_str = ""
         try:
-            message = data.decode()
+            message_str = data.decode()
+            message_data = json.loads(message_str)
         except UnicodeDecodeError:
-            _LOGGER.error("Received non UTF-8 compliant message")
-            return
-        try:
-            data = json.loads(message)
-            asyncio.create_task(self.handle_event(data))
+            _LOGGER.error("Received non UTF-8 compliant message: %s", data)
         except ValueError:
-            _LOGGER.error("Received invalid message: %s", message)
+            _LOGGER.error("Received invalid message: %s", message_str)
+        except Exception:
+            _LOGGER.exception("An unexpected error occurred while handling an UDP message.")
+        finally:
+            pass
+            asyncio.create_task(self.handle_event(message_data))
 
 
 class AsyncDevice:

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -103,7 +103,6 @@ class MusicCastUdpProtocol(asyncio.DatagramProtocol):
         except Exception:
             _LOGGER.exception("An unexpected error occurred while handling an UDP message.")
         finally:
-            pass
             asyncio.create_task(self.handle_event(message_data))
 
 


### PR DESCRIPTION
UDP messages should never lead into an exception. Instead the exceptions are being catched and logged