### PR TITLE
Add volume up and volume down methods for zones

### DIFF
--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -518,6 +518,20 @@ class MusicCastDevice:
             Zone.set_volume(zone_id, round(vol), 1)
         )
 
+    async def volume_up(self, zone_id, step=None):
+        """Turn up the volume by step or by the default step of the zone."""
+
+        await self.device.request(
+            Zone.set_volume(zone_id, "up", step)
+        )
+
+    async def volume_down(self, zone_id, step=None):
+        """Turn down the volume by step or by the default step of the zone."""
+
+        await self.device.request(
+            Zone.set_volume(zone_id, "down", step)
+        )
+
     async def netusb_play(self):
         await self.device.request(NetUSB.set_playback("play"))
 

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -933,7 +933,7 @@ class Zone:
         'GET_SOUND_PROGRAM_LIST': 'http://{host}/YamahaExtendedControl/v1/{zone}/getSoundProgramList',
         'SET_POWER': 'http://{host}/YamahaExtendedControl/v1/{zone}/setPower?power={power}',
         'SET_SLEEP': 'http://{host}/YamahaExtendedControl/v1/{zone}/setSleep?sleep={sleep}',
-        'SET_VOLUME': 'http://{host}/YamahaExtendedControl/v1/{zone}/setVolume?volume={volume}&step={step}',
+        'SET_VOLUME': 'http://{host}/YamahaExtendedControl/v1/{zone}/setVolume?volume={volume}',
         'SET_MUTE': 'http://{host}/YamahaExtendedControl/v1/{zone}/setMute?enable={enable}',
         'SET_INPUT': 'http://{host}/YamahaExtendedControl/v1/{zone}/setInput?input={input}&mode={mode}',
         'SET_SOUND_PROGRAM': 'http://{host}/YamahaExtendedControl/v1/{zone}/setSoundProgram?program={program}',
@@ -1035,9 +1035,12 @@ class Zone:
                     Values: Value range calculated by minimum/maximum/step values gotten via /system/getFeatures.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_VOLUME'].format(
-            host='{host}', zone=zone, volume=volume, step=step
+        url = Zone.URI['SET_VOLUME'].format(
+            host='{host}', zone=zone, volume=volume
         )
+        if step:
+            url += f"&step={step}"
+        return url
 
     # end-of-method set_volume
 


### PR DESCRIPTION
When using `volume_up` and `volume_down` in Home Assistant, currently it uses a fixed step size of 5% when the integration does not provide its own logic.

The API actually allows for increasing and decreasing the volume by the default step size or an arbitrary step size.

HA issue: https://github.com/home-assistant/core/issues/54139