### PR TITLE
Rewrite of alarm data structure and configure method

### DIFF
--- a/aiomusiccast/const.py
+++ b/aiomusiccast/const.py
@@ -88,3 +88,16 @@ MIME_TYPE_UPNP_CLASS = {
     "application/vnd.apple.mpegurl": "object.item.videoItem",
     "audio": "object.item.audioItem",
 }
+
+ALARM_WEEK_DAYS = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+]
+
+ALARM_ONEDAY = "oneday"
+ALARM_WEEKLY = "weekly"

--- a/aiomusiccast/features.py
+++ b/aiomusiccast/features.py
@@ -47,7 +47,8 @@ class DeviceFeature(Flag):
 
     # list of supported features that got infered indirectly
     CLOCK = auto()
-    ALARM = auto()
+    ALARM_ONEDAY = auto()
+    ALARM_WEEKLY = auto()
 
 
 # Zone Features

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -646,7 +646,7 @@ class MusicCastDevice:
             self,
             alarm_on: bool = None,
             volume: float = None,
-            alarm_time: str | time = None,
+            alarm_time: str | 'time' =None,
             source: str = None,
             mode: str = None,
             day: str = None,

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -688,23 +688,6 @@ class MusicCastDevice:
             time_parts = alarm_time.split(':')
             alarm_time = time_parts[0] + time_parts[1]
 
-        (url, body) = Clock.set_alarm_settings(
-                alarm_on=alarm_on,
-                volume=volume,
-                mode=mode,
-                day=day,
-                playback_type=playback_type,
-                alarm_time=alarm_time,
-                preset_num=preset_num,
-                preset_type=preset_type,
-                enable=enable_day,
-                resume_input=resume_input,
-                beep=beep
-            )
-
-        print(url)
-        print(json.dumps(body))
-
         await self.device.post(
             *Clock.set_alarm_settings(
                 alarm_on=alarm_on,

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -644,16 +644,27 @@ class MusicCastDevice:
 
     async def configure_alarm(
             self,
-            alarm_on=None,
-            volume=None,
-            alarm_time=None,
-            source=None,
-            mode=None,
-            day=None,
-            enable_day=None,
-            beep=None
+            alarm_on: bool = None,
+            volume: float = None,
+            alarm_time: str | time = None,
+            source: str = None,
+            mode: str = None,
+            day: str = None,
+            enable_day: bool = None,
+            beep: bool = None
     ):
-        """Setup alarm."""
+        """
+        Configure an alarm.
+        @param alarm_on: Define whether the alarm should be turned on (bool)
+        @param volume: Alarm volume 0..1 (float)
+        @param alarm_time: Alarm time in str in hh:mm form or as time object (valid only with mode and day)
+        @param source: Source for the alarm in PLAYBACKTYPE:SOURCE[:ID] form e.g. preset:netusb:2
+        (valid only with mode and day)
+        @param mode: 'oneday' or 'weekly' must be set together with day
+        @param day: Must be set with mode
+        @param enable_day: Define whether to enable the alarm for the defined day (valid only with mode and day)
+        @param beep: Define to enable the beep mode (valid only with mode and day)
+        """
         resume_input = None
         preset_type = None
         preset_num = None

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -692,13 +692,13 @@ class MusicCastDevice:
             *Clock.set_alarm_settings(
                 alarm_on=alarm_on,
                 volume=volume,
-                mode=mode if playback_type or alarm_time else None,
-                day=day if playback_type or alarm_time else None,
+                mode=mode,
+                day=day,
                 playback_type=playback_type,
                 alarm_time=alarm_time,
                 preset_num=preset_num,
                 preset_type=preset_type,
-                enable=enable_day if playback_type or alarm_time else None,
+                enable=enable_day,
                 resume_input=resume_input,
                 beep=beep
             )

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -195,7 +195,8 @@ class MusicCastDevice:
                     )
                     await self._update_input(parameter, new_zone_data.get("input", zone.input))
                 else:
-                    _LOGGER.warning("Zone %s does not exist. Available zones are: %s", parameter, self.data.zones.keys())
+                    _LOGGER.warning("Zone %s does not exist. Available zones are: %s", parameter,
+                                    self.data.zones.keys())
 
                 if new_zone_data.get("play_info_updated") or new_zone_data.get(
                         "status_updated"
@@ -405,7 +406,10 @@ class MusicCastDevice:
                 if feature_bit:
                     self.features |= feature_bit
                 else:
-                    _LOGGER.info("The model %s supports the feature %s which is not known to aiomusiccast. Please consider opening an issue on GitHub to tell us about this feature so we can implement it.", self.data.model_name, feature)
+                    _LOGGER.info(
+                        "The model %s supports the feature %s which is not known to aiomusiccast. Please consider "
+                        "opening an issue on GitHub to tell us about this feature so we can implement it.",
+                        self.data.model_name, feature)
 
             self._zone_ids = [zone.get("id") for zone in self._features.get("zone", [])]
 
@@ -426,7 +430,10 @@ class MusicCastDevice:
                     if feature_bit:
                         zone_data.features |= feature_bit
                     else:
-                        _LOGGER.info("Zone %s of model %s supports the feature %s which is not known to aiomusiccast. Please consider opening an issue on GitHub to tell us about this feature so we can implement it.", zone_id, self.data.model_name, feature)
+                        _LOGGER.info(
+                            "Zone %s of model %s supports the feature %s which is not known to aiomusiccast. Please "
+                            "consider opening an issue on GitHub to tell us about this feature so we can implement it.",
+                            zone_id, self.data.model_name, feature)
 
                 if ZoneFeature.VOLUME in zone_data.features:
                     range_volume = next(
@@ -439,7 +446,8 @@ class MusicCastDevice:
                 self.data.zones[zone_id] = zone_data
 
             if "clock" in self._features.keys():
-                if "alarm" in self._features.get('clock', {}).get('func_list', []):
+                if "alarm" in self._features.get('clock', {}).get('func_list', []) and \
+                        "oneday" in self._features.get('clock', {}).get('alarm_mode_list', []):
                     self.features |= DeviceFeature.ALARM
 
                 if "date_and_time" in self._features.get('clock', {}).get(
@@ -600,8 +608,8 @@ class MusicCastDevice:
         sleep_time = math.ceil(sleep_time / 30) * 30
         await self.device.get(Zone.set_sleep(zone_id, sleep_time))
 
-    async def configure_alarm(self, enable=None, volume=None, alarm_time=None, source=""):
-        """Setup alarm"""
+    async def configure_oneday_alarm(self, enable=None, volume=None, alarm_time=None, source=""):
+        """Setup oneday alarm."""
         enable = self.data.alarm_enabled if enable is None else enable
         resume_input = None
         preset_type = None

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -2032,7 +2032,7 @@ class Clock:
                          under /system/getFeatures.
                          This parameter is valid only when playback_type "preset" is specified.
         """
-        payload = {'detail': dict()}
+        payload = {}
         if alarm_on is not None:
             assert isinstance(alarm_on, bool), "alarm_on has to be a boolean"
             payload['alarm_on'] = alarm_on
@@ -2056,45 +2056,50 @@ class Clock:
             assert day in Clock.DAYS, "day has to be one of the following " + str(
                 Clock.DAYS
             )
+            payload['detail'] = {}
             payload['detail']['day'] = day
-        if enable is not None:
-            assert isinstance(enable, bool), "enable has to be a bool"
-            payload['detail']['enable'] = enable
-        if alarm_time is not None:
-            assert isinstance(alarm_time, str), "time has to be a str"
-            payload['detail']['time'] = alarm_time
-        if beep is not None:
-            assert isinstance(beep, bool), "beep has to be a bool"
-            payload['detail']['beep'] = beep
-        if playback_type is not None:
-            assert playback_type in [
-                'resume',
-                'preset',
-            ], "playback_type has to be resume or preset"
-            payload['detail']['playback_type'] = playback_type
-            if playback_type == 'resume':
-                payload['detail']['resume'] = dict()
-                if resume_input is not None:
-                    assert isinstance(resume_input, str), "resume_input has to be a str"
-                    payload['detail']['resume']['input'] = resume_input
-            else:
-                payload['detail']['preset'] = dict()
-                if preset_num is not None:
-                    assert isinstance(
-                        preset_num, int
-                    ), "preset_num has to be an integer"
-                    payload['detail']['preset']['num'] = preset_num
-                if preset_type is not None:
-                    assert isinstance(preset_type, str), "preset_type has to be a str"
-                    payload['detail']['preset']['type'] = preset_type
-                if preset_snooze is not None:
-                    assert isinstance(
-                        preset_snooze, bool
-                    ), "preset_snooze has to be a bool"
-                    payload['detail']['preset']['snooze'] = preset_snooze
+            if enable is not None:
+                assert isinstance(enable, bool), "enable has to be a bool"
+                payload['detail']['enable'] = enable
+            if alarm_time is not None:
+                assert isinstance(alarm_time, str), "time has to be a str"
+                payload['detail']['time'] = alarm_time
+            if beep is not None:
+                assert isinstance(beep, bool), "beep has to be a bool"
+                payload['detail']['beep'] = beep
+            if playback_type is not None:
+                assert playback_type in [
+                    'resume',
+                    'preset',
+                ], "playback_type has to be resume or preset"
+                payload['detail']['playback_type'] = playback_type
+                if playback_type == 'resume':
+                    payload['detail']['resume'] = dict()
+                    if resume_input is not None:
+                        assert isinstance(resume_input, str), "resume_input has to be a str"
+                        payload['detail']['resume']['input'] = resume_input
 
-        if len(payload['detail']) == 0:
-            del payload['detail']
+                    assert preset_type is None, "preset_type is not compatible with playback_type resume"
+                    assert preset_num is None, "preset_num is not compatible with playback_type resume"
+                    assert preset_snooze is None, "preset_snooze is not compatible with playback_type resume"
+                else:
+                    payload['detail']['preset'] = dict()
+                    if preset_num is not None:
+                        assert isinstance(
+                            preset_num, int
+                        ), "preset_num has to be an integer"
+                        payload['detail']['preset']['num'] = preset_num
+                    if preset_type is not None:
+                        assert isinstance(preset_type, str), "preset_type has to be a str"
+                        payload['detail']['preset']['type'] = preset_type
+                    if preset_snooze is not None:
+                        assert isinstance(
+                            preset_snooze, bool
+                        ), "preset_snooze has to be a bool"
+                        payload['detail']['preset']['snooze'] = preset_snooze
+
+                    assert resume_input is None, "resume_input is not compatible with playback_type preset"
+
         return Clock.URI['SET_ALARM_SETTINGS'], payload
 
 

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -1980,7 +1980,7 @@ class Clock:
 
     @staticmethod
     def set_alarm_settings(
-            alarm_on,
+            alarm_on=None,
             volume=None,
             fade_interval=None,
             fade_type=None,
@@ -2001,9 +2001,9 @@ class Clock:
         Arguments:
         @param alarm_on: Specifies alarm function status on/off
         @param volume: Specifies alarm volume value
-                  Vaule Range : calculated by minimum/maximum/step value gotten via /system/getFeatures "alarm_volume"
+                  Value Range : calculated by minimum/maximum/step value gotten via /system/getFeatures "alarm_volume"
         @param fade_interval: Specifies alarm fade interval (unit in second)
-                         Vaule Range : calculated by minimum/maximum/step
+                         Value Range : calculated by minimum/maximum/step
                          value gotten via /system/getFeatures "alarm_fade"
         @param fade_type: Specifies alarm fade type
                      Value : 1 ~ fade_type_max ( value gotten via /system/getFeatures)
@@ -2011,11 +2011,12 @@ class Clock:
                 Value : one gotten via /system/getFeatures "alarm_mode_list"
         @param repeat: Specifies repeat setting. This parameter is valid only when alarm mode "oneday" is specified
         @param day: Specifies target date for alarm setting.
-               This parameter is specified certainly when set detail parameters.
-               Value : "oneday" / "sunday" / "monday" / "tuesday" / "wednesday " / "thursday" / "friday" / "saturday"
+                   This parameter is specified certainly when set detail parameters.
+                   Value: "oneday" / "sunday" / "monday" / "tuesday" / "wednesday " / "thursday" / "friday" / "saturday"
         @param enable: 対象日のアラーム設定の有効/無効を指定します。:> WTF?
+                    According to google translate: Specify whether to enable/disable the alarm setting for the target day
         @param alarm_time: Specifies alarm start-up time.
-        Format is "hhmm" Values : hh : 00 ~ 23 (Hour) mm : 00 ~ 59 (Minute)
+                        Format is "hhmm" Values : hh : 00 ~ 23 (Hour) mm : 00 ~ 59 (Minute)
         @param beep: Specifies whether or not beep is valid.
         @param playback_type: Specifies playback type Value : "resume" / "preset"
         @param resume_input: Specifies target Input ID to playback for resume.
@@ -2031,8 +2032,10 @@ class Clock:
                          under /system/getFeatures.
                          This parameter is valid only when playback_type "preset" is specified.
         """
-        assert isinstance(alarm_on, bool), "alarm_on has to be a boolean"
-        payload = {'alarm_on': alarm_on, 'detail': dict()}
+        payload = {'detail': dict()}
+        if alarm_on is not None:
+            assert isinstance(alarm_on, bool), "alarm_on has to be a boolean"
+            payload['alarm_on'] = alarm_on
         if volume is not None:
             assert isinstance(volume, int), "volume has to be an integer"
             payload['volume'] = volume


### PR DESCRIPTION
To support the weekly alarms of Yamaha MusicCast a new data structure was needed. In addition the configure function was rewritten. In theory we should support this in aiomusiccast now - however as our devices support the oneday alarm only, it is untested for the time being.