### PR TITLE
Add category to musiccast device

### DIFF
--- a/aiomusiccast/category.py
+++ b/aiomusiccast/category.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class Category(Enum):
+    UNKNOWN = 0
+    AV_RECEIVER = 1
+    SOUNDBAR = 2
+    STEREO_RECEIVER = 3
+    SUBWOOFER = 4
+    MINI_SYSTEM = 5
+    DESKTOP_AUDIO_1 = 6

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -1,4 +1,5 @@
 import mimetypes
+from aiomusiccast.category import Category
 
 from aiomusiccast.const import DEVICE_FUNC_LIST_TO_FEATURE_MAPPING, DeviceFeature, ZONE_FUNC_LIST_TO_FEATURE_MAPPING, \
     ZoneFeature, MIME_TYPE_UPNP_CLASS, ALARM_WEEK_DAYS, ALARM_ONEDAY, ALARM_WEEKLY
@@ -142,6 +143,7 @@ class MusicCastDevice:
 
     device: AsyncDevice
     features: DeviceFeature = DeviceFeature.NONE
+    category: Category = Category.UNKNOWN
 
     def __init__(self, ip, client, upnp_description=None):
         """Init dummy MusicCastDevice."""
@@ -421,6 +423,8 @@ class MusicCastDevice:
 
         if not self._device_info:
             self._device_info = await self.device.request_json(System.get_device_info())
+
+            self.category = Category(self._device_info.get("category_code", 0))
 
             self.data.device_id = self._device_info.get("device_id")
             self.data.model_name = self._device_info.get("model_name")


### PR DESCRIPTION
We could use the category in HA to determine the [device class](https://www.home-assistant.io/integrations/media_player/#device-class). Sadly, my R-N402D doesn't have the category_code and I find the category names quite confusing, but maybe if we crowdsource information on those models we could have an override list and a better understanding of these categories