### PR TITLE
Polling needs to be enabled explicitly

### DIFF
--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -458,8 +458,6 @@ class MusicCastDevice:
 
     async def fetch(self):
         """Fetch data from musiccast device."""
-        if self.device.transport is None:
-            await self.device.enable_polling()
         if not self._network_status:
             self._network_status = await self.device.request_json(System.get_network_status())
 

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -173,6 +173,7 @@ class AsyncDevice:
         self._headers = {}
 
         self._transport.close()
+        self._transport = None
 
     async def request(self, *args):
         """Request YamahaExtendedControl API URI.


### PR DESCRIPTION
To ensure that users only enable polling, if they want to, it will not be enabled automatically on fetch anymore. To make it easy to check whether polling is enabled or not, the transport will be set to None on disable