### PR TITLE
Hotfix for enable_polling

### DIFF
--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -169,6 +169,8 @@ class AsyncDevice:
             {"X-AppName": "MusicCast/1.0", "X-AppPort": str(port)}
         )
 
+        await self.request_json(System.get_device_info())
+
     def disable_polling(self):
         self._headers = {}
 


### PR DESCRIPTION
When enable_polling is called, the device should directly start to send packages to the created socket. This was not the case until now, because an additional call was necessary to let the device know, where to send the packages to.