### PR TITLE
Add sound_program_names to MusicCastData

### DIFF
--- a/aiomusiccast/musiccast_data.py
+++ b/aiomusiccast/musiccast_data.py
@@ -42,6 +42,7 @@ class MusicCastData:
         # features
         self.zones: Dict[str, MusicCastZoneData] = {}
         self.input_names: Dict[str, str] = {}
+        self.sound_program_names: Dict[str, str] = {}
 
         # NetUSB data
         self.netusb_input = None

--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -498,6 +498,11 @@ class MusicCastDevice:
             for source in self._name_text.get("input_list")
         }
 
+        self.data.sound_program_names = {
+            program.get("id"): program.get("text")
+            for program in self._name_text.get("sound_program_list")
+        }
+
         if "netusb" in self._features.keys() and self._features.get("netusb").get("func_list"):
             await self._fetch_netusb()
             await self._fetch_netusb_presets()


### PR DESCRIPTION
We should display the sound programs in a more user-friendly way. As the API provides labels for these programs, they could simply be exposed in MusicCastData - just like we do it for the sources.