### PR TITLE
Fix group join in newer firmwares

### DIFF
--- a/aiomusiccast/musiccast_device.py
+++ b/aiomusiccast/musiccast_device.py
@@ -1209,12 +1209,11 @@ class MusicCastDevice:
     async def mc_client_join(self, server_ip, group_id, zone, retry=True):
         """Join the given group as a client."""
         async with self.data.group_update_lock:
-            await self.device.post(*Dist.set_client_info(group_id, zone, server_ip))
+            await self.device.post(*Dist.set_client_info(group_id, [zone], server_ip))
             await self.device.request(Zone.set_input(zone, MC_LINK, ""))
             if await self.check_group_data(
                     [
                         lambda: self._check_group_id(group_id),
-                        lambda: self._check_group_role("client"),
                         lambda: self._check_source(MC_LINK, zone),
                     ]
             ):

--- a/aiomusiccast/pyamaha.py
+++ b/aiomusiccast/pyamaha.py
@@ -395,7 +395,7 @@ class Dist:
     # end-of-method set_server_info
 
     @staticmethod
-    def set_client_info(group_id, zone=None, server_ip_address=None):
+    def set_client_info(group_id, zones=None, server_ip_address=None):
         """For setting Link distributed clients. If a Device is already setup as Link distribution server, this
            client setup is denied by that Device: use this API after canceling a Device's Link distribution
            server setup using setServerInfo, then confirming that the target Device's role is changed to other
@@ -406,15 +406,15 @@ class Dist:
                         Specify "" (empty text) here to cancel a Device being a Link
                         distributed client. Group ID will be initialized ("000...") after
                         the cancel operation.
-            @param zone: Specifies which target Zone ID to be a Link distributed
+            @param zones: Specifies which target Zone ID to be a Link distributed
                     client. Not necessary to specify when cancelling a client status.
                     Values: "main" / "zone2" / "zone3" / "zone4"
             @param server_ip_address: Specifies the IP Address of the Link distribution server.
         """
         data = {'group_id': group_id}
 
-        if zone is not None:
-            data['zone'] = zone
+        if zones is not None:
+            data['zone'] = zones
 
         if server_ip_address is not None:
             data['server_ip_address'] = server_ip_address


### PR DESCRIPTION
With the last firmware upgrade yamaha changed the behavior of some newer devices. The role of a newly added client changes after the set_client_info call first to none instead of client. After the server starts the distribution, this changes to client again. We won't check the role of a newly added client now anymore.
In addition, I realized that in the musiccast app an array of zones is sent to the device instead of a single zone, so I changed this, too.